### PR TITLE
Test CodeRabbit finishing touches, docstrings, and merge conflicts

### DIFF
--- a/services/pondering.py
+++ b/services/pondering.py
@@ -29,6 +29,15 @@ class PonderingService:
             for msg in prompt_messages
         ]
 
+    def _format_classification_log_message(
+        self,
+        result: PonderingResult,
+    ) -> str:
+        return (
+            f"Pondering classified: valid={result.is_valid}, "
+            f"category={result.category}"
+        )
+
     async def process_message(
         self,
         user_id: UUID,
@@ -62,10 +71,7 @@ class PonderingService:
 
         # 3. Parse response
         result = PonderingResult.parse(response.content)
-        logger.info(
-            f"Pondering classified: valid={result.is_valid}, "
-            f"category={result.category}"
-        )
+        logger.info(self._format_classification_log_message(result))
 
         # 4. Map category string to enum
         category = PonderingCategory(result.category)

--- a/services/pondering.py
+++ b/services/pondering.py
@@ -21,6 +21,14 @@ class PonderingService:
     def __init__(self):
         self.ai_client = create_ai_client("anthropic")
 
+    def _build_ai_messages(self, message_text: str) -> list[AIMessage]:
+        """Build the AI client message payload for a pondering request."""
+        prompt_messages = create_pondering_messages(message_text)
+        return [
+            AIMessage(role=msg.role, content=msg.content)
+            for msg in prompt_messages
+        ]
+
     async def process_message(
         self,
         user_id: UUID,
@@ -38,11 +46,7 @@ class PonderingService:
             The created Pondering if valid, None if classification failed
         """
         # 1. Create classification prompt
-        prompt_messages = create_pondering_messages(message_text)
-        ai_messages = [
-            AIMessage(role=msg.role, content=msg.content)
-            for msg in prompt_messages
-        ]
+        ai_messages = self._build_ai_messages(message_text)
 
         # 2. Call LLM for classification
         logger.info(f"Classifying pondering (user={user_id})")
@@ -82,4 +86,3 @@ class PonderingService:
             f"has_interpretation={result.interpretation is not None}"
         )
         return pondering
-


### PR DESCRIPTION
## Summary
This PR adds small, low-risk Python changes in `services/pondering.py` and a large batch of inert fixture files under `rate-limit-fixtures/` so CodeRabbit has enough changed files to exercise finishing touches, docstrings, merge-conflict handling, and file-count rate-limit behavior.

## Config Verification Goals
The `main` branch now includes these enabled custom finishing-touch recipes in `.coderabbit.yaml`:
- `cleanup stale imports`
- `tighten python typing`
- `polish logging calls`

Use this PR to verify:
- whether all three recipes render under `✨ Finishing Touches` in the walkthrough
- whether `@coderabbitai run <recipe name>` works for each recipe
- whether the visible recipe count changes between Pro and Pro+ entitlements
- whether the docstrings finishing touch identifies and documents the intentionally undocumented helper in `services/pondering.py`
- whether your merge-conflict handling flow behaves correctly on a PR with deliberate content conflicts against `main`
- whether the PR exceeds the current paid Pro git `filesPerHour` cap for rate-limit testing

## Rate-Limit Test Setup
- Added `rate-limit-fixtures/README.md`
- Added `305` tiny inert fixture files under `rate-limit-fixtures/pro-files-cap/`
- The current branch now changes more than `300` files against `main`

## Suggested Checks
1. Open the CodeRabbit walkthrough on this PR.
2. Look under `✨ Finishing Touches` for the three recipe names above.
3. Trigger one recipe from the checkbox UI.
4. Trigger one recipe via comment, for example:
   `@coderabbitai run cleanup stale imports`
5. Trigger the docstrings finishing touch and confirm it targets the undocumented helper added in this PR.
6. Confirm the PR shows or behaves as a merge-conflicted branch against `main`.
7. Use this PR to observe file-count rate-limit behavior when the changed-file count is above the paid Pro git cap.

## Notes
- This PR is intentionally artificial; it exists to validate config behavior, not to ship a feature.
- The config change itself was already pushed directly to `main` before opening this PR.
- `main` and this branch intentionally diverge on the same `services/pondering.py` lines, including the `MAX_TOKENS` constant and the classification logging hunk.
